### PR TITLE
feat: switch to `verify_kzg_proof` with fallback

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,4 +38,4 @@ jobs:
         run: |
           rustup install nightly-2024-10-30
           rustup component add rust-src --toolchain nightly-2024-10-30
-          cargo nextest run --release
+          OPENVM_FAST_TEST=1 cargo nextest run --release

--- a/tests/programs/verify_kzg/src/main.rs
+++ b/tests/programs/verify_kzg/src/main.rs
@@ -32,11 +32,12 @@ pub fn main() {
 
     let io: KzgInputs = read();
 
-    KzgProof::assert_kzg_proof(
+    KzgProof::verify_kzg_proof(
         &io.commitment_bytes,
         &io.z_bytes,
         &io.y_bytes,
         &io.proof_bytes,
         &kzg_settings,
-    );
+    )
+    .unwrap();
 }

--- a/tests/programs/verify_kzg/src/main.rs
+++ b/tests/programs/verify_kzg/src/main.rs
@@ -32,7 +32,7 @@ pub fn main() {
 
     let io: KzgInputs = read();
 
-    KzgProof::verify_kzg_proof(
+    let success = KzgProof::verify_kzg_proof(
         &io.commitment_bytes,
         &io.z_bytes,
         &io.y_bytes,
@@ -40,4 +40,5 @@ pub fn main() {
         &kzg_settings,
     )
     .unwrap();
+    assert!(success);
 }


### PR DESCRIPTION
Easier to integrate with `revm` if we still keep `verify_kzg_proof` but fallback to the non-intrinsic implementation of pairing if pairing check fails.