### PR TITLE
fix: error handling of parsing G1Affine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,12 +431,26 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitcode"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae9f4d868fa036ee7517b997dc2b6efd383a8b2efdcb4b07058260de060d3ef"
+checksum = "18c1406a27371b2f76232a2259df6ab607b91b5a0a7476a7729ff590df5a969a"
 dependencies = [
+ "arrayvec",
+ "bitcode_derive",
  "bytemuck",
+ "glam",
  "serde",
+]
+
+[[package]]
+name = "bitcode_derive"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b6b4cb608b8282dc3b53d0f4c9ab404655d562674c682db7e6c0458cc83c23"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1329,6 +1343,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "glam"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17fcdf9683c406c2fc4d124afd29c0d595e22210d633cbdb8695ba9935ab1dc6"
+
+[[package]]
 name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2087,7 +2107,7 @@ checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 [[package]]
 name = "openvm"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "bytemuck",
  "hex-literal",
@@ -2102,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-circuit"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -2131,7 +2151,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-complex-macros"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -2141,7 +2161,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-guest"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "halo2curves-axiom 0.5.3",
  "num-bigint 0.4.6",
@@ -2157,7 +2177,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-moduli-macros"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -2167,7 +2187,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-transpiler"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "openvm-algebra-guest",
  "openvm-instructions",
@@ -2182,7 +2202,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-circuit"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -2204,7 +2224,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-guest"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
@@ -2217,7 +2237,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-transpiler"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "openvm-bigint-guest",
  "openvm-instructions",
@@ -2232,7 +2252,7 @@ dependencies = [
 [[package]]
 name = "openvm-build"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "cargo_metadata",
  "dirs",
@@ -2247,7 +2267,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "async-trait",
  "backtrace",
@@ -2283,7 +2303,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-derive"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -2294,7 +2314,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "bitcode",
  "derive-new 0.6.0",
@@ -2312,7 +2332,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives-derive"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -2321,9 +2341,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "openvm-continuations"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
+dependencies = [
+ "derivative",
+ "openvm-circuit",
+ "openvm-native-circuit",
+ "openvm-native-compiler",
+ "openvm-native-recursion",
+ "openvm-stark-backend",
+ "openvm-stark-sdk",
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2333,7 +2369,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-circuit"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -2365,7 +2401,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-guest"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -2394,7 +2430,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-sw-macros"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -2404,7 +2440,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-transpiler"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "openvm-ecc-guest",
  "openvm-instructions",
@@ -2418,7 +2454,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
@@ -2435,7 +2471,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions-derive"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2445,7 +2481,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-circuit"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "bitcode",
  "derive-new 0.6.0",
@@ -2474,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-guest"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "openvm-platform",
  "serde",
@@ -2484,7 +2520,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-transpiler"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -2549,7 +2585,7 @@ dependencies = [
 [[package]]
 name = "openvm-macros-common"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "syn 2.0.98",
 ]
@@ -2557,7 +2593,7 @@ dependencies = [
 [[package]]
 name = "openvm-mod-circuit-builder"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint 0.4.6",
@@ -2576,7 +2612,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-circuit"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "bitcode",
  "derive-new 0.6.0",
@@ -2604,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-compiler"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "backtrace",
  "itertools 0.14.0",
@@ -2627,7 +2663,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-compiler-derive"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2637,7 +2673,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-recursion"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "cfg-if",
  "itertools 0.14.0",
@@ -2663,7 +2699,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-circuit"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -2693,7 +2729,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-guest"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "group 0.13.0",
  "halo2curves-axiom 0.5.3",
@@ -2719,7 +2755,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-transpiler"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -2733,7 +2769,7 @@ dependencies = [
 [[package]]
 name = "openvm-platform"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "getrandom 0.2.15",
  "libm",
@@ -2746,7 +2782,7 @@ dependencies = [
 [[package]]
 name = "openvm-poseidon2-air"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "derivative",
  "itertools 0.14.0",
@@ -2766,7 +2802,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32-adapters"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -2787,7 +2823,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-circuit"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "bitcode",
  "derive-new 0.6.0",
@@ -2813,7 +2849,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-guest"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "openvm-custom-insn",
  "strum_macros",
@@ -2822,7 +2858,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-transpiler"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "openvm-custom-insn",
  "openvm-instructions",
@@ -2839,7 +2875,7 @@ dependencies = [
 [[package]]
 name = "openvm-sdk"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -2858,6 +2894,7 @@ dependencies = [
  "openvm-bigint-transpiler",
  "openvm-build",
  "openvm-circuit",
+ "openvm-continuations",
  "openvm-ecc-circuit",
  "openvm-ecc-transpiler",
  "openvm-keccak256-circuit",
@@ -2882,7 +2919,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-air"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "openvm-circuit-primitives",
  "openvm-stark-backend",
@@ -2893,7 +2930,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-circuit"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "bitcode",
  "derive-new 0.6.0",
@@ -2917,7 +2954,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-guest"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "openvm",
  "openvm-platform",
@@ -2927,7 +2964,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-transpiler"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -2941,9 +2978,9 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/stark-backend.git?rev=c662bccdfafaa36fa19ab0a96ff3a0947f8331d0#c662bccdfafaa36fa19ab0a96ff3a0947f8331d0"
+source = "git+https://github.com/openvm-org/stark-backend.git?rev=fdb808bec40ff21dce7e462c2c18dbb997207adb#fdb808bec40ff21dce7e462c2c18dbb997207adb"
 dependencies = [
- "async-trait",
+ "bitcode",
  "cfg-if",
  "derivative",
  "derive-new 0.7.0",
@@ -2967,7 +3004,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/stark-backend.git?rev=c662bccdfafaa36fa19ab0a96ff3a0947f8331d0#c662bccdfafaa36fa19ab0a96ff3a0947f8331d0"
+source = "git+https://github.com/openvm-org/stark-backend.git?rev=fdb808bec40ff21dce7e462c2c18dbb997207adb#fdb808bec40ff21dce7e462c2c18dbb997207adb"
 dependencies = [
  "derivative",
  "derive_more 0.99.19",
@@ -3002,7 +3039,7 @@ dependencies = [
 [[package]]
 name = "openvm-transpiler"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "derive_more 1.0.0",
  "elf",

--- a/crates/kzg/Cargo.toml
+++ b/crates/kzg/Cargo.toml
@@ -5,9 +5,9 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-openvm-algebra-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "c79ce5498da2edbe060d0e141b942c88f0bd226b" }
-openvm-ecc-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "c79ce5498da2edbe060d0e141b942c88f0bd226b" }
-openvm-pairing-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "c79ce5498da2edbe060d0e141b942c88f0bd226b", features = ["bls12_381"] }
+openvm-algebra-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "7f87e1ddfb420a2c73c141c8ce35990f4c93086a" }
+openvm-ecc-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "7f87e1ddfb420a2c73c141c8ce35990f4c93086a" }
+openvm-pairing-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "7f87e1ddfb420a2c73c141c8ce35990f4c93086a", features = ["bls12_381"] }
 
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 hex-literal = "0.4.1"
@@ -22,21 +22,21 @@ serde-big-array = { version = "0.5.1", default-features = false }
 [target.'cfg(not(target_os = "zkvm"))'.dependencies]
 num-bigint = { version = "0.4.6", default-features = false }
 num-traits = { version = "0.2.19", default-features = false }
-openvm-pairing-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "c79ce5498da2edbe060d0e141b942c88f0bd226b", features = ["halo2curves"] }
+openvm-pairing-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "7f87e1ddfb420a2c73c141c8ce35990f4c93086a", features = ["halo2curves"] }
 
 [dev-dependencies]
 serde_yaml = { version = "0.9", default-features = false }
 
 [build-dependencies]
-openvm-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "c79ce5498da2edbe060d0e141b942c88f0bd226b", default-features = false }
-openvm-ecc-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "c79ce5498da2edbe060d0e141b942c88f0bd226b", default-features = false }
-openvm-pairing-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "c79ce5498da2edbe060d0e141b942c88f0bd226b", default-features = false, features = ["bls12_381"] }
-openvm-transpiler = { git = "https://github.com/openvm-org/openvm.git", rev = "c79ce5498da2edbe060d0e141b942c88f0bd226b", default-features = false }
+openvm-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "7f87e1ddfb420a2c73c141c8ce35990f4c93086a", default-features = false }
+openvm-ecc-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "7f87e1ddfb420a2c73c141c8ce35990f4c93086a", default-features = false }
+openvm-pairing-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "7f87e1ddfb420a2c73c141c8ce35990f4c93086a", default-features = false, features = ["bls12_381"] }
+openvm-transpiler = { git = "https://github.com/openvm-org/openvm.git", rev = "7f87e1ddfb420a2c73c141c8ce35990f4c93086a", default-features = false }
 bls12_381 = { version = "0.8.0", default-features = false, features = ["groups", "pairings", "alloc"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 
 [target.'cfg(not(target_os = "zkvm"))'.build-dependencies]
-openvm-pairing-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "c79ce5498da2edbe060d0e141b942c88f0bd226b", features = ["halo2curves"] }
+openvm-pairing-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "7f87e1ddfb420a2c73c141c8ce35990f4c93086a", features = ["halo2curves"] }
 
 [features]
 default = ["use-intrinsics"]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -4,19 +4,19 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-openvm = { git = "https://github.com/openvm-org/openvm.git", rev = "c79ce5498da2edbe060d0e141b942c88f0bd226b" }
-openvm-sdk = { git = "https://github.com/openvm-org/openvm.git", rev = "c79ce5498da2edbe060d0e141b942c88f0bd226b" }
-openvm-build = { git = "https://github.com/openvm-org/openvm.git", rev = "c79ce5498da2edbe060d0e141b942c88f0bd226b" }
-openvm-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "c79ce5498da2edbe060d0e141b942c88f0bd226b", features = ["parallel", "mimalloc", "test-utils"] }
-openvm-algebra-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "c79ce5498da2edbe060d0e141b942c88f0bd226b" }
-openvm-algebra-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "c79ce5498da2edbe060d0e141b942c88f0bd226b" }
-openvm-ecc-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "c79ce5498da2edbe060d0e141b942c88f0bd226b" }
-openvm-ecc-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "c79ce5498da2edbe060d0e141b942c88f0bd226b" }
-openvm-pairing-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "c79ce5498da2edbe060d0e141b942c88f0bd226b" }
-openvm-pairing-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "c79ce5498da2edbe060d0e141b942c88f0bd226b", features = ["bls12_381"] }
+openvm = { git = "https://github.com/openvm-org/openvm.git", rev = "7f87e1ddfb420a2c73c141c8ce35990f4c93086a" }
+openvm-sdk = { git = "https://github.com/openvm-org/openvm.git", rev = "7f87e1ddfb420a2c73c141c8ce35990f4c93086a" }
+openvm-build = { git = "https://github.com/openvm-org/openvm.git", rev = "7f87e1ddfb420a2c73c141c8ce35990f4c93086a" }
+openvm-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "7f87e1ddfb420a2c73c141c8ce35990f4c93086a", features = ["parallel", "mimalloc", "test-utils"] }
+openvm-algebra-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "7f87e1ddfb420a2c73c141c8ce35990f4c93086a" }
+openvm-algebra-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "7f87e1ddfb420a2c73c141c8ce35990f4c93086a" }
+openvm-ecc-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "7f87e1ddfb420a2c73c141c8ce35990f4c93086a" }
+openvm-ecc-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "7f87e1ddfb420a2c73c141c8ce35990f4c93086a" }
+openvm-pairing-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "7f87e1ddfb420a2c73c141c8ce35990f4c93086a" }
+openvm-pairing-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "7f87e1ddfb420a2c73c141c8ce35990f4c93086a", features = ["bls12_381"] }
 openvm-kzg = { path = "../crates/kzg", features = ["test-utils"] }
 
-openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", rev = "c662bccdfafaa36fa19ab0a96ff3a0947f8331d0" }
+openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", rev = "fdb808bec40ff21dce7e462c2c18dbb997207adb" }
 
 hex = { version = "0.4.3", features = ["alloc"] }
 hex-literal = "0.4.1"

--- a/tests/programs/verify_kzg/Cargo.lock
+++ b/tests/programs/verify_kzg/Cargo.lock
@@ -175,12 +175,26 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "bitcode"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee1bce7608560cd4bf0296a4262d0dbf13e6bcec5ff2105724c8ab88cc7fc784"
+checksum = "18c1406a27371b2f76232a2259df6ab607b91b5a0a7476a7729ff590df5a969a"
 dependencies = [
+ "arrayvec",
+ "bitcode_derive",
  "bytemuck",
+ "glam",
  "serde",
+]
+
+[[package]]
+name = "bitcode_derive"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b6b4cb608b8282dc3b53d0f4c9ab404655d562674c682db7e6c0458cc83c23"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.92",
 ]
 
 [[package]]
@@ -645,6 +659,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "glam"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17fcdf9683c406c2fc4d124afd29c0d595e22210d633cbdb8695ba9935ab1dc6"
+
+[[package]]
 name = "group"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1093,7 +1113,7 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 [[package]]
 name = "openvm"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "bytemuck",
  "hex-literal",
@@ -1108,7 +1128,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-complex-macros"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -1118,7 +1138,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-guest"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "halo2curves-axiom",
  "num-bigint 0.4.6",
@@ -1134,7 +1154,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-moduli-macros"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -1144,7 +1164,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "async-trait",
  "backtrace",
@@ -1178,7 +1198,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-derive"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -1189,7 +1209,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "bitcode",
  "derive-new 0.6.0",
@@ -1207,7 +1227,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives-derive"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -1218,7 +1238,7 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1228,7 +1248,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-guest"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -1255,7 +1275,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-sw-macros"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -1265,7 +1285,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
@@ -1282,7 +1302,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions-derive"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1313,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "openvm-macros-common"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "syn 2.0.92",
 ]
@@ -1321,7 +1341,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-guest"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "group 0.13.0",
  "halo2curves-axiom",
@@ -1347,7 +1367,7 @@ dependencies = [
 [[package]]
 name = "openvm-platform"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "getrandom",
  "libm",
@@ -1360,7 +1380,7 @@ dependencies = [
 [[package]]
 name = "openvm-poseidon2-air"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "derivative",
  "itertools 0.14.0",
@@ -1380,7 +1400,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-guest"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "openvm-custom-insn",
  "strum_macros",
@@ -1389,9 +1409,9 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/stark-backend.git?rev=c662bccdfafaa36fa19ab0a96ff3a0947f8331d0#c662bccdfafaa36fa19ab0a96ff3a0947f8331d0"
+source = "git+https://github.com/openvm-org/stark-backend.git?rev=fdb808bec40ff21dce7e462c2c18dbb997207adb#fdb808bec40ff21dce7e462c2c18dbb997207adb"
 dependencies = [
- "async-trait",
+ "bitcode",
  "cfg-if",
  "derivative",
  "derive-new 0.7.0",
@@ -1413,7 +1433,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/stark-backend.git?rev=c662bccdfafaa36fa19ab0a96ff3a0947f8331d0#c662bccdfafaa36fa19ab0a96ff3a0947f8331d0"
+source = "git+https://github.com/openvm-org/stark-backend.git?rev=fdb808bec40ff21dce7e462c2c18dbb997207adb#fdb808bec40ff21dce7e462c2c18dbb997207adb"
 dependencies = [
  "derivative",
  "derive_more 0.99.18",
@@ -1448,7 +1468,7 @@ dependencies = [
 [[package]]
 name = "openvm-transpiler"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/openvm-org/openvm.git?rev=c79ce5498da2edbe060d0e141b942c88f0bd226b#c79ce5498da2edbe060d0e141b942c88f0bd226b"
+source = "git+https://github.com/openvm-org/openvm.git?rev=7f87e1ddfb420a2c73c141c8ce35990f4c93086a#7f87e1ddfb420a2c73c141c8ce35990f4c93086a"
 dependencies = [
  "derive_more 1.0.0",
  "elf",

--- a/tests/programs/verify_kzg/Cargo.toml
+++ b/tests/programs/verify_kzg/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 resolver = "2"
 
 [dependencies]
-openvm = { git = "https://github.com/openvm-org/openvm.git", rev = "c79ce5498da2edbe060d0e141b942c88f0bd226b" }
-openvm-algebra-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "c79ce5498da2edbe060d0e141b942c88f0bd226b" }
-openvm-ecc-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "c79ce5498da2edbe060d0e141b942c88f0bd226b" }
-openvm-pairing-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "c79ce5498da2edbe060d0e141b942c88f0bd226b", features = ["bls12_381"] }
+openvm = { git = "https://github.com/openvm-org/openvm.git", rev = "7f87e1ddfb420a2c73c141c8ce35990f4c93086a" }
+openvm-algebra-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "7f87e1ddfb420a2c73c141c8ce35990f4c93086a" }
+openvm-ecc-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "7f87e1ddfb420a2c73c141c8ce35990f4c93086a" }
+openvm-pairing-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "7f87e1ddfb420a2c73c141c8ce35990f4c93086a", features = ["bls12_381"] }
 openvm-kzg = { path = "../../../crates/kzg", default-features = false, features = ["use-intrinsics"] }


### PR DESCRIPTION
Update openvm commit.
Make sure that when parsing `G1Affine` from compressed bytes format, we return errors if the parsing fails. We make sure this happens regardless of whether host is honest or not.

closes INT-3627