### PR TITLE
fix: `include_bytes` can be misaligned

### DIFF
--- a/crates/kzg/src/dtypes.rs
+++ b/crates/kzg/src/dtypes.rs
@@ -7,6 +7,7 @@ use bls12_381::Scalar;
 
 macro_rules! define_bytes_type {
     ($name:ident, $size:expr) => {
+        #[repr(C, align(16))]
         #[derive(Debug, Clone)]
         pub struct $name(pub(crate) [u8; $size]);
 

--- a/crates/kzg/src/trusted_setup.rs
+++ b/crates/kzg/src/trusted_setup.rs
@@ -1,25 +1,45 @@
 use crate::{types::KzgSettings, NUM_G1_POINTS, NUM_G2_POINTS, NUM_ROOTS_OF_UNITY};
 
 use bls12_381::{G1Affine, G2Affine, Scalar};
-use core::slice;
+use core::{mem::align_of, slice};
 use spin::Once;
 
-// Newtype to force alignment. We over-align to 16 bytes.
-#[repr(align(16))]
-struct Aligned<T>(T);
+// https://users.rust-lang.org/t/can-i-conveniently-compile-bytes-into-a-rust-program-with-a-specific-alignment/24049/2
+#[repr(C)] // guarantee 'bytes' comes after '_align'
+pub struct AlignedAs<Align, Bytes: ?Sized> {
+    pub _align: [Align; 0],
+    pub bytes: Bytes,
+}
+
+macro_rules! include_bytes_align_as {
+    ($align_ty:ty, $path:expr) => {{
+        // const block expression to encapsulate the static
+
+        // this assignment is made possible by CoerceUnsized
+        static ALIGNED: &AlignedAs<$align_ty, [u8]> = &AlignedAs {
+            _align: [],
+            bytes: *include_bytes!($path),
+        };
+
+        &ALIGNED.bytes
+    }};
+}
 
 pub fn get_roots_of_unity() -> &'static [Scalar] {
     static ROOTS_OF_UNITY: Once<&'static [Scalar]> = Once::new();
     ROOTS_OF_UNITY.call_once(|| {
-        static ALIGNED_BYTES: Aligned<&[u8]> = Aligned(include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../assets/trusted_setup/roots_of_unity.bin"
-        )));
+        static ALIGNED_BYTES: &[u8] = include_bytes_align_as!(
+            Scalar,
+            concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../../assets/trusted_setup/roots_of_unity.bin"
+            )
+        );
         // The minimum alignment required is 4
-        assert!(ALIGNED_BYTES.0.as_ptr() as usize % 4 == 0);
+        assert!(ALIGNED_BYTES.as_ptr() as usize % align_of::<Scalar>() == 0);
         unsafe {
             slice::from_raw_parts::<Scalar>(
-                ALIGNED_BYTES.0.as_ptr() as *const Scalar,
+                ALIGNED_BYTES.as_ptr() as *const Scalar,
                 NUM_ROOTS_OF_UNITY,
             )
         }
@@ -29,15 +49,18 @@ pub fn get_roots_of_unity() -> &'static [Scalar] {
 pub fn get_g1_points() -> &'static [G1Affine] {
     static G1_POINTS: Once<&'static [G1Affine]> = Once::new();
     G1_POINTS.call_once(|| {
-        static ALIGNED_BYTES: Aligned<&[u8]> = Aligned(include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../assets/trusted_setup/g1.bin"
-        )));
+        static ALIGNED_BYTES: &[u8] = include_bytes_align_as!(
+            G1Affine,
+            concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../../assets/trusted_setup/g1.bin"
+            )
+        );
         // The minimum alignment required is 4
-        assert!(ALIGNED_BYTES.0.as_ptr() as usize % 4 == 0);
+        assert!(ALIGNED_BYTES.as_ptr() as usize % align_of::<G1Affine>() == 0);
         unsafe {
             slice::from_raw_parts::<G1Affine>(
-                ALIGNED_BYTES.0.as_ptr() as *const G1Affine,
+                ALIGNED_BYTES.as_ptr() as *const G1Affine,
                 NUM_G1_POINTS,
             )
         }
@@ -47,15 +70,18 @@ pub fn get_g1_points() -> &'static [G1Affine] {
 pub fn get_g2_points() -> &'static [G2Affine] {
     static G2_POINTS: Once<&'static [G2Affine]> = Once::new();
     G2_POINTS.call_once(|| {
-        static ALIGNED_BYTES: Aligned<&[u8]> = Aligned(include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../assets/trusted_setup/g2.bin"
-        )));
+        static ALIGNED_BYTES: &[u8] = include_bytes_align_as!(
+            G2Affine,
+            concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../../assets/trusted_setup/g2.bin"
+            )
+        );
         // The minimum alignment required is 4
-        assert!(ALIGNED_BYTES.0.as_ptr() as usize % 4 == 0);
+        assert!(ALIGNED_BYTES.as_ptr() as usize % align_of::<G2Affine>() == 0);
         unsafe {
             slice::from_raw_parts::<G2Affine>(
-                ALIGNED_BYTES.0.as_ptr() as *const G2Affine,
+                ALIGNED_BYTES.as_ptr() as *const G2Affine,
                 NUM_G2_POINTS,
             )
         }

--- a/crates/kzg/src/trusted_setup.rs
+++ b/crates/kzg/src/trusted_setup.rs
@@ -1,39 +1,64 @@
 use crate::{types::KzgSettings, NUM_G1_POINTS, NUM_G2_POINTS, NUM_ROOTS_OF_UNITY};
 
 use bls12_381::{G1Affine, G2Affine, Scalar};
-use core::{mem::transmute, slice};
+use core::slice;
 use spin::Once;
+
+// Newtype to force alignment. We over-align to 16 bytes.
+#[repr(align(16))]
+struct Aligned<T>(T);
 
 pub fn get_roots_of_unity() -> &'static [Scalar] {
     static ROOTS_OF_UNITY: Once<&'static [Scalar]> = Once::new();
     ROOTS_OF_UNITY.call_once(|| {
-        let bytes = include_bytes!(concat!(
+        static ALIGNED_BYTES: Aligned<&[u8]> = Aligned(include_bytes!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/../../assets/trusted_setup/roots_of_unity.bin"
-        ));
-        unsafe { transmute(slice::from_raw_parts(bytes.as_ptr(), NUM_ROOTS_OF_UNITY)) }
+        )));
+        // The minimum alignment required is 4
+        assert!(ALIGNED_BYTES.0.as_ptr() as usize % 4 == 0);
+        unsafe {
+            slice::from_raw_parts::<Scalar>(
+                ALIGNED_BYTES.0.as_ptr() as *const Scalar,
+                NUM_ROOTS_OF_UNITY,
+            )
+        }
     })
 }
 
 pub fn get_g1_points() -> &'static [G1Affine] {
     static G1_POINTS: Once<&'static [G1Affine]> = Once::new();
     G1_POINTS.call_once(|| {
-        let bytes = include_bytes!(concat!(
+        static ALIGNED_BYTES: Aligned<&[u8]> = Aligned(include_bytes!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/../../assets/trusted_setup/g1.bin"
-        ));
-        unsafe { transmute(slice::from_raw_parts(bytes.as_ptr(), NUM_G1_POINTS)) }
+        )));
+        // The minimum alignment required is 4
+        assert!(ALIGNED_BYTES.0.as_ptr() as usize % 4 == 0);
+        unsafe {
+            slice::from_raw_parts::<G1Affine>(
+                ALIGNED_BYTES.0.as_ptr() as *const G1Affine,
+                NUM_G1_POINTS,
+            )
+        }
     })
 }
 
 pub fn get_g2_points() -> &'static [G2Affine] {
     static G2_POINTS: Once<&'static [G2Affine]> = Once::new();
     G2_POINTS.call_once(|| {
-        let bytes = include_bytes!(concat!(
+        static ALIGNED_BYTES: Aligned<&[u8]> = Aligned(include_bytes!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/../../assets/trusted_setup/g2.bin"
-        ));
-        unsafe { transmute(slice::from_raw_parts(bytes.as_ptr(), NUM_G2_POINTS)) }
+        )));
+        // The minimum alignment required is 4
+        assert!(ALIGNED_BYTES.0.as_ptr() as usize % 4 == 0);
+        unsafe {
+            slice::from_raw_parts::<G2Affine>(
+                ALIGNED_BYTES.0.as_ptr() as *const G2Affine,
+                NUM_G2_POINTS,
+            )
+        }
     })
 }
 


### PR DESCRIPTION
The use of `unsafe` slice conversions elided the fact that the alignment of `&[Scalar]` is expected to be the alignment of `Scalar`, whereas `include_bytes!` only guarantees alignment to `&[u8]` which has alignment `1`.