### PR TITLE
chore(DON'T MERGE): use openvm main branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 tmp/
 
 **/Cargo.lock
+
+*.vmexe

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,8 +1539,13 @@ checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
 name = "openvm"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "bytemuck",
  "getrandom 0.2.15",
@@ -1554,8 +1559,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-circuit"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -1583,8 +1593,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-complex-macros"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -1593,8 +1608,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-guest"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "halo2curves-axiom",
  "num-bigint 0.4.6",
@@ -1609,8 +1629,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-moduli-macros"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "num-bigint 0.4.6",
  "num-prime",
@@ -1621,8 +1646,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-transpiler"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "openvm-algebra-guest",
  "openvm-instructions",
@@ -1635,8 +1665,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-bigint-circuit"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -1658,8 +1693,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-bigint-guest"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "openvm-platform",
  "strum_macros",
@@ -1667,8 +1707,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-bigint-transpiler"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "openvm-bigint-guest",
  "openvm-instructions",
@@ -1682,8 +1727,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-build"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "cargo_metadata",
  "eyre",
@@ -1694,11 +1744,18 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "backtrace",
  "cfg-if",
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+dependencies = [
+ "backtrace",
+>>>>>>> a0e8432 (chore: use openvm main branch)
  "dashmap",
  "derivative",
  "derive-new 0.6.0",
@@ -1729,8 +1786,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit-derive"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -1740,15 +1802,23 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit-primitives"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
  "num-bigint 0.4.6",
  "num-traits",
  "openvm-circuit-primitives-derive",
+<<<<<<< HEAD
  "openvm-cuda-builder",
+=======
+>>>>>>> a0e8432 (chore: use openvm main branch)
  "openvm-stark-backend",
  "rand",
  "tracing",
@@ -1756,8 +1826,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit-primitives-derive"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -1766,8 +1841,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-continuations"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "derivative",
  "openvm-circuit",
@@ -1791,7 +1871,11 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
+<<<<<<< HEAD
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1800,8 +1884,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-circuit"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -1829,8 +1918,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-guest"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -1848,8 +1942,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-sw-macros"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -1858,8 +1957,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-transpiler"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "openvm-ecc-guest",
  "openvm-instructions",
@@ -1872,8 +1976,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-instructions"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
@@ -1889,8 +1998,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-instructions-derive"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -1898,8 +2012,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-keccak256-circuit"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -1923,16 +2042,26 @@ dependencies = [
 
 [[package]]
 name = "openvm-keccak256-guest"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "openvm-platform",
 ]
 
 [[package]]
 name = "openvm-keccak256-transpiler"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -1968,16 +2097,26 @@ dependencies = [
 
 [[package]]
 name = "openvm-macros-common"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "syn 2.0.100",
 ]
 
 [[package]]
 name = "openvm-mod-circuit-builder"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "itertools 0.14.0",
  "num-bigint 0.4.6",
@@ -1994,8 +2133,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-circuit"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -2013,7 +2157,10 @@ dependencies = [
  "openvm-rv32im-transpiler",
  "openvm-stark-backend",
  "openvm-stark-sdk",
+<<<<<<< HEAD
  "p3-field",
+=======
+>>>>>>> a0e8432 (chore: use openvm main branch)
  "rand",
  "serde",
  "static_assertions",
@@ -2022,8 +2169,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-compiler"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "backtrace",
  "itertools 0.14.0",
@@ -2044,8 +2196,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-compiler-derive"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -2053,8 +2210,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-recursion"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "cfg-if",
  "itertools 0.14.0",
@@ -2077,8 +2239,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-transpiler"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "openvm-instructions",
  "openvm-transpiler",
@@ -2087,8 +2254,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "group 0.13.0",
  "halo2curves-axiom",
@@ -2112,8 +2284,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing-circuit"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -2141,8 +2318,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing-guest"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "halo2curves-axiom",
  "hex-literal 0.4.1",
@@ -2162,8 +2344,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing-transpiler"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "openvm-instructions",
  "openvm-pairing-guest",
@@ -2175,8 +2362,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-platform"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "libm",
  "openvm-custom-insn",
@@ -2185,12 +2377,20 @@ dependencies = [
 
 [[package]]
 name = "openvm-poseidon2-air"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "derivative",
  "lazy_static",
  "openvm-cuda-builder",
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+dependencies = [
+ "derivative",
+ "lazy_static",
+>>>>>>> a0e8432 (chore: use openvm main branch)
  "openvm-stark-backend",
  "openvm-stark-sdk",
  "p3-monty-31",
@@ -2203,8 +2403,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32-adapters"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -2220,8 +2425,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32im-circuit"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -2243,8 +2453,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32im-guest"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "openvm-custom-insn",
  "p3-field",
@@ -2253,8 +2468,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32im-transpiler"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -2269,8 +2489,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-sdk"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "bitcode",
  "bon",
@@ -2323,8 +2548,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-air"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "openvm-circuit-primitives",
  "openvm-stark-backend",
@@ -2334,8 +2564,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-circuit"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -2357,16 +2592,26 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-guest"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "openvm-platform",
 ]
 
 [[package]]
 name = "openvm-sha256-transpiler"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -2379,8 +2624,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-stark-backend"
+<<<<<<< HEAD
 version = "1.2.0"
 source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0#64c72dba9db8dedad1c936a04fa344b4b9ecb1cd"
+=======
+version = "1.2.0-rc.0"
+source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0-rc.2#c8eb4dde511b068b6b23dc48d7b0695897d5a00a"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "bitcode",
  "cfg-if",
@@ -2405,8 +2655,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-stark-sdk"
+<<<<<<< HEAD
 version = "1.2.0"
 source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0#64c72dba9db8dedad1c936a04fa344b4b9ecb1cd"
+=======
+version = "1.2.0-rc.0"
+source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0-rc.2#c8eb4dde511b068b6b23dc48d7b0695897d5a00a"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "dashmap",
  "derivative",
@@ -2442,8 +2697,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-transpiler"
+<<<<<<< HEAD
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+=======
+version = "1.4.0-rc.4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 dependencies = [
  "elf",
  "eyre",
@@ -3047,6 +3307,18 @@ dependencies = [
 [[package]]
 name = "redox_syscall"
 version = "0.5.13"
+<<<<<<< HEAD
+=======
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+>>>>>>> a0e8432 (chore: use openvm main branch)
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,14 +3,51 @@
 version = 4
 
 [[package]]
-name = "addchain"
-version = "0.2.0"
+name = "abi_stable"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2e69442aa5628ea6951fa33e24efe8313f4321a91bd729fc2f75bdfc858570"
+checksum = "69d6512d3eb05ffe5004c59c206de7f99c34951504056ce23fc953842f12c445"
 dependencies = [
- "num-bigint 0.3.3",
- "num-integer",
- "num-traits",
+ "abi_stable_derive",
+ "abi_stable_shared",
+ "const_panic",
+ "core_extensions",
+ "crossbeam-channel",
+ "generational-arena",
+ "libloading",
+ "lock_api",
+ "parking_lot",
+ "paste",
+ "repr_offset",
+ "rustc_version",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "abi_stable_derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7178468b407a4ee10e881bc7a328a65e739f0863615cca4429d43916b05e898"
+dependencies = [
+ "abi_stable_shared",
+ "as_derive_utils",
+ "core_extensions",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 1.0.109",
+ "typed-arena",
+]
+
+[[package]]
+name = "abi_stable_shared"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b5df7688c123e63f4d4d649cba63f2967ba7f7861b1664fca3f77d3dad2b63"
+dependencies = [
+ "core_extensions",
 ]
 
 [[package]]
@@ -142,7 +179,7 @@ dependencies = [
  "derivative",
  "digest",
  "itertools 0.10.5",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "paste",
  "rustc_version",
@@ -165,7 +202,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -180,7 +217,7 @@ checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-std",
  "digest",
- "num-bigint 0.4.6",
+ "num-bigint",
 ]
 
 [[package]]
@@ -190,7 +227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -204,6 +241,18 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "as_derive_utils"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff3c96645900a44cf11941c111bd08a6573b0e2f9f69bc9264b179d8fae753c4"
+dependencies = [
+ "core_extensions",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "autocfg"
@@ -332,7 +381,7 @@ dependencies = [
  "ff 0.12.1",
  "group 0.12.1",
  "pairing 0.22.0",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -345,7 +394,35 @@ dependencies = [
  "ff 0.13.1",
  "group 0.13.0",
  "pairing 0.23.0",
- "rand_core",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "blst"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
+name = "blstrs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a8a8ed6fefbeef4a8c7b460e4110e12c5e22a5b7cf32621aae6ad650c4dcf29"
+dependencies = [
+ "blst",
+ "byte-slice-cast",
+ "ff 0.13.1",
+ "group 0.13.0",
+ "pairing 0.23.0",
+ "rand_core 0.6.4",
+ "serde",
  "subtle",
 ]
 
@@ -379,6 +456,12 @@ name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytemuck"
@@ -421,7 +504,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -507,16 +590,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const_panic"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e262cdaac42494e3ae34c43969f9cdeb7da178bdb4b66fa6a1ea2edb4c8ae652"
+dependencies = [
+ "typewit",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation-sys"
@@ -525,12 +611,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core_extensions"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42bb5e5d0269fd4f739ea6cedaf29c16d81c27a7ce7582008e90eb50dcd57003"
+dependencies = [
+ "core_extensions_proc_macros",
+]
+
+[[package]]
+name = "core_extensions_proc_macros"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533d38ecd2709b7608fb8e18e4504deb99e9a72879e6aa66373a76d8dc4259ea"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -571,7 +681,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -691,19 +801,6 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "derive_more"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
@@ -776,7 +873,7 @@ dependencies = [
  "ff 0.13.1",
  "generic-array",
  "group 0.13.0",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -839,7 +936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
  "bitvec",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -850,25 +947,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "bitvec",
- "byteorder",
- "ff_derive",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
-]
-
-[[package]]
-name = "ff_derive"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f10d12652036b0e99197587c6ba87a8fc3031986499973c030d8b44fcc151b60"
-dependencies = [
- "addchain",
- "num-bigint 0.3.3",
- "num-integer",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -890,10 +970,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
-name = "gcd"
-version = "2.3.0"
+name = "generational-arena"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
+checksum = "877e94aff08e743b651baaea359664321055749b398adff8740a7399af7796e7"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "generic-array"
@@ -967,7 +1050,7 @@ checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff 0.12.1",
  "memuse",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -978,7 +1061,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff 0.13.1",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "rand_xorshift",
  "subtle",
 ]
 
@@ -1001,44 +1086,14 @@ dependencies = [
  "ff 0.12.1",
  "group 0.12.1",
  "pasta_curves 0.4.1",
- "rand_core",
+ "rand_core 0.6.4",
  "rayon",
-]
-
-[[package]]
-name = "halo2curves"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b756596082144af6e57105a20403b7b80fe9dccd085700b74fae3af523b74dba"
-dependencies = [
- "blake2",
- "digest",
- "ff 0.13.1",
- "group 0.13.0",
- "halo2derive",
- "hex",
- "lazy_static",
- "num-bigint 0.4.6",
- "num-integer",
- "num-traits",
- "pairing 0.23.0",
- "paste",
- "rand",
- "rand_core",
- "rayon",
- "serde",
- "serde_arrays",
- "sha2",
- "static_assertions",
- "subtle",
- "unroll",
 ]
 
 [[package]]
 name = "halo2curves-axiom"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8309e4638b4f1bcf6613d72265a84074d26034c35edc5d605b5688e580b8b8"
+version = "0.7.2"
+source = "git+https://github.com/axiom-crypto/halo2curves.git?tag=v0.7.2#3a65a710e27fe03711f6fb4fc0c4469ae351974a"
 dependencies = [
  "blake2b_simd",
  "digest",
@@ -1046,13 +1101,13 @@ dependencies = [
  "group 0.13.0",
  "hex",
  "lazy_static",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "pairing 0.23.0",
  "pasta_curves 0.5.1",
  "paste",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "rayon",
  "serde",
  "serde_arrays",
@@ -1060,20 +1115,6 @@ dependencies = [
  "static_assertions",
  "subtle",
  "unroll",
-]
-
-[[package]]
-name = "halo2derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb99e7492b4f5ff469d238db464131b86c2eaac814a78715acba369f64d2c76"
-dependencies = [
- "num-bigint 0.4.6",
- "num-integer",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1252,7 +1293,7 @@ dependencies = [
  "bls12_381 0.7.1",
  "ff 0.12.1",
  "group 0.12.1",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1279,6 +1320,16 @@ name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
 
 [[package]]
 name = "libm"
@@ -1428,24 +1479,13 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "serde",
 ]
 
@@ -1470,7 +1510,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64a5fe11d4135c3bcdf3a95b18b194afa9608a5f6ff034f5d857bc9a27fb0119"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -1484,11 +1524,11 @@ dependencies = [
  "bitvec",
  "either",
  "lru",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "num-modular",
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1511,18 +1551,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nums"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3c74f925fb8cfc49a8022f2afce48a0683b70f9e439885594e84c5edbf5b01"
-dependencies = [
- "num-bigint 0.4.6",
- "num-integer",
- "num-traits",
- "rand",
-]
-
-[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,18 +1567,13 @@ checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
 name = "openvm"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "bytemuck",
  "getrandom 0.2.15",
  "getrandom 0.3.2",
- "num-bigint 0.4.6",
+ "num-bigint",
  "openvm-custom-insn",
  "openvm-platform",
  "openvm-rv32im-guest",
@@ -1559,20 +1582,16 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-circuit"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
+ "blstrs",
  "cfg-if",
  "derive-new 0.6.0",
- "derive_more 1.0.0",
+ "derive_more",
  "eyre",
  "halo2curves-axiom",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "openvm-algebra-transpiler",
  "openvm-circuit",
@@ -1585,7 +1604,7 @@ dependencies = [
  "openvm-rv32im-circuit",
  "openvm-stark-backend",
  "openvm-stark-sdk",
- "rand",
+ "rand 0.9.4",
  "serde",
  "serde_with",
  "strum",
@@ -1593,13 +1612,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-complex-macros"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -1608,16 +1622,11 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-guest"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "halo2curves-axiom",
- "num-bigint 0.4.6",
+ "num-bigint",
  "once_cell",
  "openvm-algebra-complex-macros",
  "openvm-algebra-moduli-macros",
@@ -1629,15 +1638,10 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-moduli-macros"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-prime",
  "openvm-macros-common",
  "quote",
@@ -1646,13 +1650,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-transpiler"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "openvm-algebra-guest",
  "openvm-instructions",
@@ -1665,17 +1664,12 @@ dependencies = [
 
 [[package]]
 name = "openvm-bigint-circuit"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
- "derive_more 1.0.0",
+ "derive_more",
  "openvm-bigint-transpiler",
  "openvm-circuit",
  "openvm-circuit-derive",
@@ -1687,19 +1681,14 @@ dependencies = [
  "openvm-rv32im-transpiler",
  "openvm-stark-backend",
  "openvm-stark-sdk",
- "rand",
+ "rand 0.9.4",
  "serde",
 ]
 
 [[package]]
 name = "openvm-bigint-guest"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "openvm-platform",
  "strum_macros",
@@ -1707,13 +1696,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-bigint-transpiler"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "openvm-bigint-guest",
  "openvm-instructions",
@@ -1727,13 +1711,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-build"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "cargo_metadata",
  "eyre",
@@ -1744,22 +1723,16 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
+ "abi_stable",
  "backtrace",
  "cfg-if",
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
-dependencies = [
- "backtrace",
->>>>>>> a0e8432 (chore: use openvm main branch)
  "dashmap",
  "derivative",
  "derive-new 0.6.0",
- "derive_more 1.0.0",
+ "derive_more",
  "enum_dispatch",
  "eyre",
  "getset",
@@ -1775,24 +1748,19 @@ dependencies = [
  "openvm-stark-sdk",
  "p3-baby-bear",
  "p3-field",
- "rand",
+ "rand 0.9.4",
  "rustc-hash",
  "serde",
  "serde-big-array",
  "static_assertions",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
 [[package]]
 name = "openvm-circuit-derive"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -1802,37 +1770,24 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit-primitives"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "openvm-circuit-primitives-derive",
-<<<<<<< HEAD
  "openvm-cuda-builder",
-=======
->>>>>>> a0e8432 (chore: use openvm main branch)
  "openvm-stark-backend",
- "rand",
+ "rand 0.9.4",
  "tracing",
 ]
 
 [[package]]
 name = "openvm-circuit-primitives-derive"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -1841,13 +1796,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-continuations"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "derivative",
  "openvm-circuit",
@@ -1855,14 +1805,15 @@ dependencies = [
  "openvm-native-recursion",
  "openvm-stark-backend",
  "openvm-stark-sdk",
+ "p3-bn254",
  "serde",
  "static_assertions",
 ]
 
 [[package]]
 name = "openvm-cuda-builder"
-version = "1.2.0"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0#64c72dba9db8dedad1c936a04fa344b4b9ecb1cd"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.4.0#2d4c6da0c84f43b15fcdac84ce13fd2325148c66"
 dependencies = [
  "cc",
  "glob",
@@ -1871,11 +1822,7 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-<<<<<<< HEAD
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1884,21 +1831,17 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-circuit"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
+ "blstrs",
  "cfg-if",
  "derive-new 0.6.0",
- "derive_more 1.0.0",
+ "derive_more",
  "halo2curves-axiom",
  "hex-literal 0.4.1",
  "lazy_static",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "once_cell",
  "openvm-algebra-circuit",
@@ -1910,7 +1853,7 @@ dependencies = [
  "openvm-mod-circuit-builder",
  "openvm-rv32-adapters",
  "openvm-stark-backend",
- "rand",
+ "rand 0.9.4",
  "serde",
  "serde_with",
  "strum",
@@ -1918,13 +1861,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-guest"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -1942,13 +1880,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-sw-macros"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -1957,13 +1890,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-transpiler"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "openvm-ecc-guest",
  "openvm-instructions",
@@ -1976,18 +1904,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-instructions"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
  "itertools 0.14.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "openvm-instructions-derive",
  "openvm-stark-backend",
@@ -1998,13 +1921,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-instructions-derive"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -2012,17 +1930,12 @@ dependencies = [
 
 [[package]]
 name = "openvm-keccak256-circuit"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
- "derive_more 1.0.0",
+ "derive_more",
  "itertools 0.14.0",
  "openvm-circuit",
  "openvm-circuit-derive",
@@ -2034,7 +1947,7 @@ dependencies = [
  "openvm-stark-backend",
  "openvm-stark-sdk",
  "p3-keccak-air",
- "rand",
+ "rand 0.9.4",
  "serde",
  "strum",
  "tiny-keccak",
@@ -2042,26 +1955,16 @@ dependencies = [
 
 [[package]]
 name = "openvm-keccak256-guest"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "openvm-platform",
 ]
 
 [[package]]
 name = "openvm-keccak256-transpiler"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -2097,29 +2000,19 @@ dependencies = [
 
 [[package]]
 name = "openvm-macros-common"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "syn 2.0.100",
 ]
 
 [[package]]
 name = "openvm-mod-circuit-builder"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "itertools 0.14.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "openvm-circuit",
  "openvm-circuit-primitives",
@@ -2127,23 +2020,19 @@ dependencies = [
  "openvm-instructions",
  "openvm-stark-backend",
  "openvm-stark-sdk",
- "rand",
+ "rand 0.8.5",
+ "rand 0.9.4",
  "tracing",
 ]
 
 [[package]]
 name = "openvm-native-circuit"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
- "derive_more 1.0.0",
+ "derive_more",
  "eyre",
  "itertools 0.14.0",
  "openvm-circuit",
@@ -2157,11 +2046,8 @@ dependencies = [
  "openvm-rv32im-transpiler",
  "openvm-stark-backend",
  "openvm-stark-sdk",
-<<<<<<< HEAD
  "p3-field",
-=======
->>>>>>> a0e8432 (chore: use openvm main branch)
- "rand",
+ "rand 0.9.4",
  "serde",
  "static_assertions",
  "strum",
@@ -2169,17 +2055,12 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-compiler"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "backtrace",
  "itertools 0.14.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "openvm-circuit",
  "openvm-instructions",
@@ -2196,13 +2077,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-compiler-derive"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -2210,13 +2086,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-recursion"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "cfg-if",
  "itertools 0.14.0",
@@ -2231,7 +2102,8 @@ dependencies = [
  "p3-fri",
  "p3-merkle-tree",
  "p3-symmetric",
- "rand",
+ "rand 0.8.5",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "tracing",
@@ -2239,13 +2111,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-transpiler"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "openvm-instructions",
  "openvm-transpiler",
@@ -2254,19 +2121,14 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "group 0.13.0",
  "halo2curves-axiom",
  "hex-literal 0.4.1",
  "itertools 0.14.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "openvm",
  "openvm-algebra-complex-macros",
@@ -2278,26 +2140,20 @@ dependencies = [
  "openvm-pairing-guest",
  "openvm-platform",
  "openvm-rv32im-guest",
- "rand",
  "serde",
 ]
 
 [[package]]
 name = "openvm-pairing-circuit"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
- "derive_more 1.0.0",
+ "derive_more",
  "eyre",
  "halo2curves-axiom",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "openvm-algebra-circuit",
  "openvm-circuit",
@@ -2311,46 +2167,36 @@ dependencies = [
  "openvm-pairing-transpiler",
  "openvm-rv32im-circuit",
  "openvm-stark-backend",
- "rand",
+ "rand 0.9.4",
  "serde",
  "strum",
 ]
 
 [[package]]
 name = "openvm-pairing-guest"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
+ "blstrs",
  "halo2curves-axiom",
  "hex-literal 0.4.1",
  "itertools 0.14.0",
  "lazy_static",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "openvm",
  "openvm-algebra-guest",
  "openvm-algebra-moduli-macros",
  "openvm-custom-insn",
  "openvm-ecc-guest",
- "rand",
  "serde",
  "strum_macros",
 ]
 
 [[package]]
 name = "openvm-pairing-transpiler"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "openvm-instructions",
  "openvm-pairing-guest",
@@ -2362,13 +2208,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-platform"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "libm",
  "openvm-custom-insn",
@@ -2377,39 +2218,25 @@ dependencies = [
 
 [[package]]
 name = "openvm-poseidon2-air"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "derivative",
  "lazy_static",
  "openvm-cuda-builder",
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
-dependencies = [
- "derivative",
- "lazy_static",
->>>>>>> a0e8432 (chore: use openvm main branch)
  "openvm-stark-backend",
  "openvm-stark-sdk",
- "p3-monty-31",
  "p3-poseidon2",
  "p3-poseidon2-air",
  "p3-symmetric",
- "rand",
+ "rand 0.9.4",
  "zkhash",
 ]
 
 [[package]]
 name = "openvm-rv32-adapters"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -2420,24 +2247,19 @@ dependencies = [
  "openvm-rv32im-circuit",
  "openvm-stark-backend",
  "openvm-stark-sdk",
- "rand",
+ "rand 0.9.4",
 ]
 
 [[package]]
 name = "openvm-rv32im-circuit"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
- "derive_more 1.0.0",
+ "derive_more",
  "eyre",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "openvm-circuit",
  "openvm-circuit-derive",
@@ -2446,20 +2268,15 @@ dependencies = [
  "openvm-instructions",
  "openvm-rv32im-transpiler",
  "openvm-stark-backend",
- "rand",
+ "rand 0.9.4",
  "serde",
  "strum",
 ]
 
 [[package]]
 name = "openvm-rv32im-guest"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "openvm-custom-insn",
  "p3-field",
@@ -2468,13 +2285,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32im-transpiler"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -2489,26 +2301,21 @@ dependencies = [
 
 [[package]]
 name = "openvm-sdk"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "bitcode",
  "bon",
  "cfg-if",
  "clap",
  "derivative",
- "derive_more 1.0.0",
+ "derive_more",
  "eyre",
  "getset",
  "hex",
  "itertools 0.14.0",
  "metrics",
- "num-bigint 0.4.6",
+ "num-bigint",
  "openvm",
  "openvm-algebra-circuit",
  "openvm-algebra-transpiler",
@@ -2534,47 +2341,38 @@ dependencies = [
  "openvm-stark-backend",
  "openvm-stark-sdk",
  "openvm-transpiler",
+ "p3-bn254",
  "p3-fri",
- "rand",
+ "rand 0.9.4",
  "rrs-lib",
  "serde",
  "serde_json",
  "serde_with",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "toml",
  "tracing",
 ]
 
 [[package]]
 name = "openvm-sha256-air"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "openvm-circuit-primitives",
  "openvm-stark-backend",
- "rand",
+ "rand 0.9.4",
  "sha2",
 ]
 
 [[package]]
 name = "openvm-sha256-circuit"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
- "derive_more 1.0.0",
+ "derive_more",
  "openvm-circuit",
  "openvm-circuit-derive",
  "openvm-circuit-primitives",
@@ -2584,7 +2382,7 @@ dependencies = [
  "openvm-sha256-transpiler",
  "openvm-stark-backend",
  "openvm-stark-sdk",
- "rand",
+ "rand 0.9.4",
  "serde",
  "sha2",
  "strum",
@@ -2592,26 +2390,16 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-guest"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "openvm-platform",
 ]
 
 [[package]]
 name = "openvm-sha256-transpiler"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -2624,18 +2412,14 @@ dependencies = [
 
 [[package]]
 name = "openvm-stark-backend"
-<<<<<<< HEAD
-version = "1.2.0"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0#64c72dba9db8dedad1c936a04fa344b4b9ecb1cd"
-=======
-version = "1.2.0-rc.0"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0-rc.2#c8eb4dde511b068b6b23dc48d7b0695897d5a00a"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.4.0#2d4c6da0c84f43b15fcdac84ce13fd2325148c66"
 dependencies = [
  "bitcode",
  "cfg-if",
  "derivative",
  "derive-new 0.7.0",
+ "eyre",
  "itertools 0.14.0",
  "p3-air",
  "p3-challenger",
@@ -2643,38 +2427,34 @@ dependencies = [
  "p3-field",
  "p3-matrix",
  "p3-maybe-rayon",
- "p3-uni-stark",
  "p3-util",
  "rayon",
  "rustc-hash",
  "serde",
- "thiserror",
+ "serde_json",
+ "thiserror 1.0.69",
  "tikv-jemallocator",
  "tracing",
 ]
 
 [[package]]
 name = "openvm-stark-sdk"
-<<<<<<< HEAD
-version = "1.2.0"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0#64c72dba9db8dedad1c936a04fa344b4b9ecb1cd"
-=======
-version = "1.2.0-rc.0"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0-rc.2#c8eb4dde511b068b6b23dc48d7b0695897d5a00a"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.4.0#2d4c6da0c84f43b15fcdac84ce13fd2325148c66"
 dependencies = [
  "dashmap",
  "derivative",
- "derive_more 0.99.19",
+ "derive_more",
  "ff 0.13.1",
  "itertools 0.14.0",
  "metrics",
  "metrics-tracing-context",
  "metrics-util",
+ "num-bigint",
  "openvm-stark-backend",
  "p3-baby-bear",
  "p3-blake3",
- "p3-bn254-fr",
+ "p3-bn254",
  "p3-dft",
  "p3-fri",
  "p3-goldilocks",
@@ -2684,7 +2464,7 @@ dependencies = [
  "p3-poseidon",
  "p3-poseidon2",
  "p3-symmetric",
- "rand",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "static_assertions",
@@ -2697,13 +2477,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-transpiler"
-<<<<<<< HEAD
-version = "1.4.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
-=======
-version = "1.4.0-rc.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#51d0aa69694fd33def3c433e48228a5675e4fd97"
->>>>>>> a0e8432 (chore: use openvm main branch)
+version = "1.6.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=main#eda5bf031a6bd0960adb1dcf59b9a0a951eacb20"
 dependencies = [
  "elf",
  "eyre",
@@ -2711,7 +2486,7 @@ dependencies = [
  "openvm-platform",
  "openvm-stark-backend",
  "rrs-lib",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2725,8 +2500,9 @@ dependencies = [
 
 [[package]]
 name = "p3-air"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daee3082e2ca0db2ac876c43c9c8fd53204b0fcb95cfe7258d21f4a925ad82c4"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -2734,22 +2510,24 @@ dependencies = [
 
 [[package]]
 name = "p3-baby-bear"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a1a49f4d9c8b8cbdab61e25d9de1b78b3c8347dd2fb88b11d990b3efa8cdd3a"
 dependencies = [
+ "p3-challenger",
  "p3-field",
  "p3-mds",
  "p3-monty-31",
  "p3-poseidon2",
  "p3-symmetric",
- "rand",
- "serde",
+ "rand 0.9.4",
 ]
 
 [[package]]
 name = "p3-blake3"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f97fd783752532861bf29bac344b7c226a0d1e2151148834c43c651a5d401"
 dependencies = [
  "blake3",
  "p3-symmetric",
@@ -2757,27 +2535,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "p3-bn254-fr"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+name = "p3-bn254"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923bd91df7dd93481b4bfb53aa903d46d1a49d51160513472a5e95ca92ef1b46"
 dependencies = [
- "ff 0.13.1",
- "halo2curves",
- "num-bigint 0.4.6",
+ "num-bigint",
  "p3-field",
  "p3-poseidon2",
  "p3-symmetric",
- "rand",
+ "p3-util",
+ "paste",
+ "rand 0.9.4",
  "serde",
 ]
 
 [[package]]
 name = "p3-challenger"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7d2d45f5a51dc3f965e8d6da60a6c26c807e88657863d56da275eaa05ad36f1"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
+ "p3-monty-31",
  "p3-symmetric",
  "p3-util",
  "tracing",
@@ -2785,8 +2566,9 @@ dependencies = [
 
 [[package]]
 name = "p3-commit"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf6d7dcb58a8f21f0e1325dc7f7699ad749878ccbe7e286e61f9d46bde2bfa88"
 dependencies = [
  "itertools 0.14.0",
  "p3-challenger",
@@ -2799,38 +2581,40 @@ dependencies = [
 
 [[package]]
 name = "p3-dft"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beabb40bc8ac7f5f95870f271fb844c7e2e1ebb7f0761a8eebb2614b56c6b1c1"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
  "p3-matrix",
  "p3-maybe-rayon",
  "p3-util",
+ "spin 0.10.0",
  "tracing",
 ]
 
 [[package]]
 name = "p3-field"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4819a3e4c1882431a63d4847ffa10d110017aee4cb9cf4319ca6dca191930969"
 dependencies = [
  "itertools 0.14.0",
- "num-bigint 0.4.6",
- "num-integer",
- "num-traits",
- "nums",
+ "num-bigint",
  "p3-maybe-rayon",
  "p3-util",
- "rand",
+ "paste",
+ "rand 0.9.4",
  "serde",
  "tracing",
 ]
 
 [[package]]
 name = "p3-fri"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13ca6a795cfc4180425fbf16dfdb4c9c2bfa85971dd55b5930d97b513e0835df"
 dependencies = [
  "itertools 0.14.0",
  "p3-challenger",
@@ -2841,32 +2625,36 @@ dependencies = [
  "p3-matrix",
  "p3-maybe-rayon",
  "p3-util",
- "rand",
+ "rand 0.9.4",
  "serde",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "p3-goldilocks"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c47d5c650bbeb25941b9a1fa9bfaf59b3cd202a438ea2c20892489af001399"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
+ "p3-challenger",
  "p3-dft",
  "p3-field",
  "p3-mds",
- "p3-poseidon",
  "p3-poseidon2",
  "p3-symmetric",
  "p3-util",
- "rand",
+ "paste",
+ "rand 0.9.4",
  "serde",
 ]
 
 [[package]]
 name = "p3-interpolation"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27a3696641a8f4ec990ff8c91862fb4f3b4ff29f589f78005d046023fe3550f"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -2876,10 +2664,10 @@ dependencies = [
 
 [[package]]
 name = "p3-keccak"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a61b090fb42152d1fcb2f82227b8619b1b022f9cd4a123123dccc9c2ab75d5de"
 dependencies = [
- "itertools 0.14.0",
  "p3-field",
  "p3-symmetric",
  "p3-util",
@@ -2888,73 +2676,75 @@ dependencies = [
 
 [[package]]
 name = "p3-keccak-air"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4832d817455f7a4a35b598cbb8a42f1ee0430ee82df0203956c26917b2509865"
 dependencies = [
  "p3-air",
  "p3-field",
  "p3-matrix",
  "p3-maybe-rayon",
  "p3-util",
- "rand",
+ "rand 0.9.4",
  "tracing",
 ]
 
 [[package]]
 name = "p3-koala-bear"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfb02789fca0950e246123d652bd78e75a76e3b90a651fd88dbb215cd3e81f5a"
 dependencies = [
+ "p3-challenger",
  "p3-field",
- "p3-mds",
  "p3-monty-31",
  "p3-poseidon2",
  "p3-symmetric",
- "rand",
- "serde",
+ "rand 0.9.4",
 ]
 
 [[package]]
 name = "p3-matrix"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6fde449bd2963d394284ec46db8c647e6a5602d90601117b76752072ab54168"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
  "p3-maybe-rayon",
  "p3-util",
- "rand",
+ "rand 0.9.4",
  "serde",
  "tracing",
- "transpose",
 ]
 
 [[package]]
 name = "p3-maybe-rayon"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54afab3883d8a14676b492709d6c4e9fa535c36718b737db0817aacfaaaa11f6"
 dependencies = [
  "rayon",
 ]
 
 [[package]]
 name = "p3-mds"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3895055d735ac96d010747b3aaabd4c2645b9fd80226960550318db2e25afb75"
 dependencies = [
- "itertools 0.14.0",
  "p3-dft",
  "p3-field",
- "p3-matrix",
  "p3-symmetric",
  "p3-util",
- "rand",
+ "rand 0.9.4",
 ]
 
 [[package]]
 name = "p3-merkle-tree"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60e20f61ea816e94f83ed7b8134a5e98d0cad7bd6dff226bc1da17a5143c63cb"
 dependencies = [
  "itertools 0.14.0",
  "p3-commit",
@@ -2963,18 +2753,20 @@ dependencies = [
  "p3-maybe-rayon",
  "p3-symmetric",
  "p3-util",
- "rand",
+ "rand 0.9.4",
  "serde",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "p3-monty-31"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9fe0be661891af1f703ceaf57334fcbd540804988984dc2b500dd99740e7c81"
 dependencies = [
  "itertools 0.14.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "p3-dft",
  "p3-field",
  "p3-matrix",
@@ -2983,85 +2775,72 @@ dependencies = [
  "p3-poseidon2",
  "p3-symmetric",
  "p3-util",
- "rand",
+ "paste",
+ "rand 0.9.4",
  "serde",
+ "spin 0.10.0",
  "tracing",
- "transpose",
 ]
 
 [[package]]
 name = "p3-poseidon"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "548af7ff569975882bc411f653aba7d89a6d85813ca58ef922fd0b1ecb6b5866"
 dependencies = [
  "p3-field",
  "p3-mds",
  "p3-symmetric",
- "rand",
+ "rand 0.9.4",
 ]
 
 [[package]]
 name = "p3-poseidon2"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6fc2368447576283f8b3849a36095017f25addf06eab9e33b0ce7f96b0b99d"
 dependencies = [
- "gcd",
  "p3-field",
  "p3-mds",
  "p3-symmetric",
- "rand",
+ "p3-util",
+ "rand 0.9.4",
 ]
 
 [[package]]
 name = "p3-poseidon2-air"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a80481b023f74c0f8ded5058dab8054174e8060d82d400da7b67cf7f2f0a87bc"
 dependencies = [
  "p3-air",
  "p3-field",
  "p3-matrix",
  "p3-maybe-rayon",
  "p3-poseidon2",
- "p3-util",
- "rand",
- "tikv-jemallocator",
+ "rand 0.9.4",
  "tracing",
 ]
 
 [[package]]
 name = "p3-symmetric"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a14456a42a7d9e65f13999706f1bca2832175935169b3a54286e18331cf1d82f"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
  "serde",
-]
-
-[[package]]
-name = "p3-uni-stark"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
-dependencies = [
- "itertools 0.14.0",
- "p3-air",
- "p3-challenger",
- "p3-commit",
- "p3-dft",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-util",
- "serde",
- "tracing",
 ]
 
 [[package]]
 name = "p3-util"
-version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911154accf66034b0eec4452956c088f92a200b37a8225c1caed74cfbd38cc8d"
 dependencies = [
  "serde",
+ "transpose",
 ]
 
 [[package]]
@@ -3080,6 +2859,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
  "group 0.13.0",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -3105,7 +2894,7 @@ dependencies = [
  "ff 0.12.1",
  "group 0.12.1",
  "lazy_static",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
  "subtle",
 ]
@@ -3120,7 +2909,7 @@ dependencies = [
  "ff 0.13.1",
  "group 0.13.0",
  "lazy_static",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
  "subtle",
 ]
@@ -3252,8 +3041,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3263,7 +3062,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3273,6 +3082,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.2",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3286,9 +3113,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -3296,9 +3123,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -3307,18 +3134,6 @@ dependencies = [
 [[package]]
 name = "redox_syscall"
 version = "0.5.13"
-<<<<<<< HEAD
-=======
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "regex"
-version = "1.11.1"
->>>>>>> a0e8432 (chore: use openvm main branch)
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
@@ -3341,6 +3156,15 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "repr_offset"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1070755bd29dffc19d0971cab794e607839ba2ef4b69a9e6fbc8733c1b72ea"
+dependencies = [
+ "tstr",
+]
 
 [[package]]
 name = "rrs-lib"
@@ -3571,7 +3395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3597,6 +3421,9 @@ name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "static_assertions"
@@ -3691,7 +3518,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -3706,6 +3542,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3713,6 +3560,15 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]
@@ -3856,7 +3712,7 @@ checksum = "ee40835db14ddd1e3ba414292272eddde9dad04d3d4b65509656414d1c42592f"
 dependencies = [
  "ansi_term",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "tracing-subscriber",
 ]
@@ -3901,10 +3757,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "tstr"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8e0294f14baae476d0dd0a2d780b2e24d66e349a9de876f5126777a37bdba7"
+dependencies = [
+ "tstr_proc_macros",
+]
+
+[[package]]
+name = "tstr_proc_macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78122066b0cb818b8afd08f7ed22f7fdbc3e90815035726f0840d0d26c0747a"
+
+[[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "typewit"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "214ca0b2191785cbc06209b9ca1861e048e39b5ba33574b3cedd58363d5bb5f6"
 
 [[package]]
 name = "unicode-ident"
@@ -4271,7 +4154,7 @@ dependencies = [
  "jubjub",
  "lazy_static",
  "pasta_curves 0.5.1",
- "rand",
+ "rand 0.8.5",
  "serde",
  "sha2",
  "sha3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ homepage = "https://axiom.xyz"
 license = "MIT"
 
 [dependencies]
-openvm-algebra-guest = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0" }
-openvm-ecc-guest = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0" }
-openvm-pairing = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0", features = [
+openvm-algebra-guest = { git = "https://github.com/openvm-org/openvm.git", branch = "main" }
+openvm-ecc-guest = { git = "https://github.com/openvm-org/openvm.git", branch = "main" }
+openvm-pairing = { git = "https://github.com/openvm-org/openvm.git", branch = "main", features = [
     "bls12_381",
 ] }
 
@@ -37,14 +37,14 @@ serde_yaml = { version = "0.9", default-features = false }
 [target.'cfg(not(target_os = "zkvm"))'.dev-dependencies]
 openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", tag = "v1.2.0", default-features = false }
 
-openvm = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0" }
-openvm-sdk = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0" }
-openvm-build = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0" }
-openvm-circuit = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0", features = [
+openvm = { git = "https://github.com/openvm-org/openvm.git", branch = "main" }
+openvm-sdk = { git = "https://github.com/openvm-org/openvm.git", branch = "main" }
+openvm-build = { git = "https://github.com/openvm-org/openvm.git", branch = "main" }
+openvm-circuit = { git = "https://github.com/openvm-org/openvm.git", branch = "main", features = [
     "parallel",
     "test-utils",
 ] }
-openvm-pairing = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0", features = [
+openvm-pairing = { git = "https://github.com/openvm-org/openvm.git", branch = "main", features = [
     "halo2curves",
 ] }
 openvm-kzg = { path = ".", default-features = false, features = ["test-utils"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["tests/programs/verify_kzg"]
 name = "openvm-kzg"
 version = "0.2.0-alpha"
 edition = "2021"
-rust-version = "1.86"
+rust-version = "1.90"
 authors = ["Axiom"]
 homepage = "https://axiom.xyz"
 license = "MIT"
@@ -35,7 +35,7 @@ serde-big-array = { version = "0.5.1", default-features = false }
 serde_yaml = { version = "0.9", default-features = false }
 
 [target.'cfg(not(target_os = "zkvm"))'.dev-dependencies]
-openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", tag = "v1.2.0", default-features = false }
+openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", tag = "v1.4.0", default-features = false }
 
 openvm = { git = "https://github.com/openvm-org/openvm.git", branch = "main" }
 openvm-sdk = { git = "https://github.com/openvm-org/openvm.git", branch = "main" }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.90.0"
 components = ["clippy", "rustfmt", "rust-src"]
 profile = "minimal"

--- a/src/kzg_proof.rs
+++ b/src/kzg_proof.rs
@@ -188,7 +188,7 @@ fn to_openvm_g2_affine(g2: G2Affine) -> Bls12_381G2Affine {
         Fp::from_be_bytes_unchecked(&y_c0),
         Fp::from_be_bytes_unchecked(&y_c1),
     ]);
-    Bls12_381G2Affine::from_xy_unchecked(ox, oy)
+    unsafe { Bls12_381G2Affine::from_xy_unchecked(ox, oy) }
 }
 
 /// Returns true if the field element is lexicographically larger than its negation.
@@ -257,7 +257,7 @@ fn to_openvm_g1_affine(g1: G1Affine) -> Bls12_381G1Affine {
     let g1_bytes = g1.to_uncompressed();
     let x = Fp::from_be_bytes_unchecked(&g1_bytes[0..48]);
     let y = Fp::from_be_bytes_unchecked(&g1_bytes[48..96]);
-    Bls12_381G1Affine::from_xy_unchecked(x, y)
+    unsafe { Bls12_381G1Affine::from_xy_unchecked(x, y) }
 }
 
 #[cfg(not(target_os = "zkvm"))]

--- a/src/trusted_setup.rs
+++ b/src/trusted_setup.rs
@@ -36,7 +36,7 @@ pub fn get_roots_of_unity() -> &'static [Scalar] {
             )
         );
         // The minimum alignment required is 4
-        assert!(ALIGNED_BYTES.as_ptr() as usize % align_of::<Scalar>() == 0);
+        assert!((ALIGNED_BYTES.as_ptr() as usize).is_multiple_of(align_of::<Scalar>()));
         unsafe {
             slice::from_raw_parts::<Scalar>(
                 ALIGNED_BYTES.as_ptr() as *const Scalar,
@@ -54,7 +54,7 @@ pub fn get_g1_points() -> &'static [G1Affine] {
             concat!(env!("CARGO_MANIFEST_DIR"), "/assets/trusted_setup/g1.bin")
         );
         // The minimum alignment required is 4
-        assert!(ALIGNED_BYTES.as_ptr() as usize % align_of::<G1Affine>() == 0);
+        assert!((ALIGNED_BYTES.as_ptr() as usize).is_multiple_of(align_of::<G1Affine>()));
         unsafe {
             slice::from_raw_parts::<G1Affine>(
                 ALIGNED_BYTES.as_ptr() as *const G1Affine,
@@ -72,7 +72,7 @@ pub fn get_g2_points() -> &'static [G2Affine] {
             concat!(env!("CARGO_MANIFEST_DIR"), "/assets/trusted_setup/g2.bin")
         );
         // The minimum alignment required is 4
-        assert!(ALIGNED_BYTES.as_ptr() as usize % align_of::<G2Affine>() == 0);
+        assert!((ALIGNED_BYTES.as_ptr() as usize).is_multiple_of(align_of::<G2Affine>()));
         unsafe {
             slice::from_raw_parts::<G2Affine>(
                 ALIGNED_BYTES.as_ptr() as *const G2Affine,

--- a/tests/programs/verify_kzg/Cargo.toml
+++ b/tests/programs/verify_kzg/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 resolver = "2"
 
 [dependencies]
-openvm = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0" }
-openvm-algebra-guest = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0" }
-openvm-ecc-guest = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0" }
-openvm-pairing = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0", features = [
+openvm = { git = "https://github.com/openvm-org/openvm.git", branch = "main" }
+openvm-algebra-guest = { git = "https://github.com/openvm-org/openvm.git", branch = "main" }
+openvm-ecc-guest = { git = "https://github.com/openvm-org/openvm.git", branch = "main" }
+openvm-pairing = { git = "https://github.com/openvm-org/openvm.git", branch = "main", features = [
     "bls12_381",
 ] }
 


### PR DESCRIPTION
This is convenient for some cases (to avoid having multiple openvm versions). Probably it should stay in branch and not be merged but creating this PR for visibility.